### PR TITLE
Add support for negative indices and improve efficiency

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,37 @@
+#![feature(test)]
+
+extern crate obj;
+extern crate test;
+
+use test::Bencher;
+
+use obj::raw::parse_obj;
+
+fn load_file(filename: &str) -> Vec<u8> {
+    use std::path::Path;
+    use std::fs::File;
+    use std::io::Read;
+
+    let path = Path::new("tests").join("fixtures").join(filename);
+    let mut file = match File::open(&path) {
+        Ok(f) => f,
+        Err(e) => panic!("Failed to open \"{}\". \x1b[31m{}\x1b[0m", path.to_string_lossy(), e)
+    };
+
+    let mut data = Vec::new();
+    match file.read_to_end(&mut data) {
+        Err(e) => panic!("Failed to read \"{}\". \x1b[31m{}\x1b[0m", path.to_string_lossy(), e),
+        Ok(_) => ()
+    }
+
+    data
+}
+
+#[bench]
+fn sponza(b: &mut Bencher) {
+    let data = load_file("sponza.obj");
+    let mut data = std::io::Cursor::new(&data[..]);
+    b.iter(|| {
+        parse_obj(&mut data).unwrap()
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ impl<V: FromRawVertex> Obj<V> {
 }
 
 /// Conversion from `RawObj`'s raw data.
-pub trait FromRawVertex {
+pub trait FromRawVertex : Sized {
     /// Build vertex and index buffer from raw object data.
     fn process(vertices: Vec<(f32, f32, f32, f32)>, normals: Vec<(f32, f32, f32)>, polygons: Vec<Polygon>) -> ObjResult<(Vec<Self>, Vec<u16>)>;
 }

--- a/tests/raw-basics.rs
+++ b/tests/raw-basics.rs
@@ -332,3 +332,16 @@ fn dome() {
         obj.smoothing_groups[2].polygons[0].end,                62
     };
 }
+
+#[test]
+fn sponza() {
+    // Sponza atrium model, it's reasonably big and more importantly uses negative indexes
+    // for some of the face specifications.
+    let obj = fixture("sponza.obj");
+
+    test! {
+        obj.name,              Some("sponza.lwo".to_owned())
+        obj.positions.len(),   39742
+        obj.polygons.len(),    36347
+    }
+}


### PR DESCRIPTION
Wavefront .obj files support vertex indices starting from the first
defined vertex, or indices relative to the most recently defined vertex.
Previously, the code would choke on negative indices, this makes it so
it doesn't.

In the process I also made a few improvements for the sake of
performance. To avoid allocating for each line, I changed the lexer to
re-use the args buffer, growing when necessary. This required some
unsafe code to handle lifetime-related issues, but the code has a number
of comments explaining what is going on.

I also changed parsing the vertex group to avoid allocation. Instead it
parses a vertex group into a triple, using '0' to indicate a missing
value.

My benchmark (in the second commit) show a roughly 20% speedup with these changes. Going from 21ms to 17ms. Since the file I used requires support for negative indices, the comparison isn't against the current master perfectly, but I added bare-minimum support for negative indices in order to make the comparison.

Lastly, I added `Sized` bounds where indicated by the compiler due to RFC 1214.