### PR TITLE
Make the type of the index buffer generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "obj-rs"
-version = "0.4.20"
+version = "0.4.21"
 authors = ["Hyeon Kim <simnalamburt@gmail.com>"]
 homepage = "https://github.com/simnalamburt/obj-rs"
 repository = "https://github.com/simnalamburt/obj-rs"
@@ -32,6 +32,7 @@ glium = { version = "0.22.0", default-features = false, optional = true }
 vec_map = "0.6.0"
 serde = "1.0"
 serde_derive = "1.0"
+num = "0.2.0"
 
 
 [[example]]


### PR DESCRIPTION
I was attempting to load a very large mesh and the index size being a u16 was causing subtle issues. In addition to fixing my issue, I think this is a reasonable solution for #33. 