### PR TITLE
Remove expects with make_error

### DIFF
--- a/obj-rs/src/raw/object.rs
+++ b/obj-rs/src/raw/object.rs
@@ -394,7 +394,7 @@ where
 
     /// Ends a current group.
     fn end(&mut self) {
-        match mem::replace(&mut self.current, None) {
+        match self.current.take() {
             // Closed group twice, do nothing
             None => {}
             // Closing a group

--- a/obj-rs/tests/issue-63.rs
+++ b/obj-rs/tests/issue-63.rs
@@ -1,4 +1,4 @@
-use obj::{load_obj};
+use obj::load_obj;
 use std::io::Cursor;
 
 fn do_test<V: obj::FromRawVertex<u8> + std::fmt::Debug>(test_case: &str) {
@@ -22,7 +22,7 @@ fn issue_63() {
         test_case.push_str(format!("v {i}.0 {i}.0 {i}.0\n").as_str());
     }
     test_case.push_str("vt 0.0 0.0\nvn 0.0 0.0 1.0\n");
-    for i in 0..(1000-2) {
+    for i in 0..(1000 - 2) {
         let i = i + 1;
         let j = i + 1;
         let k = i + 2;

--- a/obj-rs/tests/issue-63.rs
+++ b/obj-rs/tests/issue-63.rs
@@ -29,6 +29,9 @@ fn issue_63() {
         test_case.push_str(format!("f {i}/1/1 {j}/1/1 {k}/1/1\n").as_str())
     }
 
+    load_obj::<obj::TexturedVertex, _, u16>(Cursor::new(&test_case))
+        .expect("this should load properly");
+
     do_test::<obj::Position>(&test_case);
     do_test::<obj::Vertex>(&test_case);
     do_test::<obj::TexturedVertex>(&test_case);

--- a/obj-rs/tests/issue-63.rs
+++ b/obj-rs/tests/issue-63.rs
@@ -1,11 +1,15 @@
 use obj::{load_obj};
 use std::io::Cursor;
 
-fn do_test<V: obj::FromRawVertex<u16> + std::fmt::Debug>(test_case: &str) {
+fn do_test<V: obj::FromRawVertex<u8> + std::fmt::Debug>(test_case: &str) {
     let err = load_obj::<V, _, _>(Cursor::new(test_case))
         .expect_err("Should error out due to index out of bounds");
     if let obj::ObjError::Load(err) = err {
-        assert!(matches!(err.kind(), obj::LoadErrorKind::IndexOutOfRange));
+        let expected_error = obj::LoadError::new(
+            obj::LoadErrorKind::IndexOutOfRange,
+            "Unable to convert the index from usize",
+        );
+        assert_eq!(err.to_string(), expected_error.to_string());
     } else {
         panic!("Expected a LoadError");
     }
@@ -19,6 +23,7 @@ fn issue_63() {
     }
     test_case.push_str("vt 0.0 0.0\nvn 0.0 0.0 1.0\n");
     for i in 0..(1000-2) {
+        let i = i + 1;
         let j = i + 1;
         let k = i + 2;
         test_case.push_str(format!("f {i}/1/1 {j}/1/1 {k}/1/1\n").as_str())

--- a/obj-rs/tests/issue-63.rs
+++ b/obj-rs/tests/issue-63.rs
@@ -1,0 +1,30 @@
+use obj::{load_obj};
+use std::io::Cursor;
+
+fn do_test<V: obj::FromRawVertex<u16> + std::fmt::Debug>(test_case: &str) {
+    let err = load_obj::<V, _, _>(Cursor::new(test_case))
+        .expect_err("Should error out due to index out of bounds");
+    if let obj::ObjError::Load(err) = err {
+        assert!(matches!(err.kind(), obj::LoadErrorKind::IndexOutOfRange));
+    } else {
+        panic!("Expected a LoadError");
+    }
+}
+
+#[test]
+fn issue_63() {
+    let mut test_case: String = "o LargeObj\n".into();
+    for i in 0..1000 {
+        test_case.push_str(format!("v {i}.0 {i}.0 {i}.0\n").as_str());
+    }
+    test_case.push_str("vt 0.0 0.0\nvn 0.0 0.0 1.0\n");
+    for i in 0..(1000-2) {
+        let j = i + 1;
+        let k = i + 2;
+        test_case.push_str(format!("f {i}/1/1 {j}/1/1 {k}/1/1\n").as_str())
+    }
+
+    do_test::<obj::Position>(&test_case);
+    do_test::<obj::Vertex>(&test_case);
+    do_test::<obj::TexturedVertex>(&test_case);
+}


### PR DESCRIPTION
Fixes #63. This removes any hard panicks that could result from an invalid file when an index cannot fit within the specified type, replacing it with an `Err` value on return.