### PR TITLE
Adds additional context to "Unable to convert the index from usize"

### DIFF
--- a/obj-rs/src/error.rs
+++ b/obj-rs/src/error.rs
@@ -67,7 +67,7 @@ implmnt!(Load, LoadError);
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct LoadError {
     kind: LoadErrorKind,
-    message: &'static str,
+    message: String,
 }
 
 impl LoadError {
@@ -101,6 +101,7 @@ pub enum LoadErrorKind {
 impl LoadError {
     /// Creates a new custom error from a specified kind and message.
     pub fn new(kind: LoadErrorKind, message: &'static str) -> Self {
+        let message = message.to_string();
         LoadError { kind, message }
     }
 }
@@ -136,3 +137,13 @@ macro_rules! make_error {
 }
 
 pub(crate) use make_error;
+
+pub(super) fn index_out_of_range<T, I>(index: usize) -> ObjResult<T> {
+    let name = std::any::type_name::<I>();
+    Err(ObjError::Load(LoadError {
+        kind: LoadErrorKind::IndexOutOfRange,
+        message: format!(
+            "Given index type '{name}' is not large enough to contain the index '{index}'"
+        ),
+    }))
+}

--- a/obj-rs/src/lib.rs
+++ b/obj-rs/src/lib.rs
@@ -30,7 +30,7 @@ pub mod raw;
 
 pub use crate::error::{LoadError, LoadErrorKind, ObjError, ObjResult};
 
-use crate::error::make_error;
+use crate::error::{index_out_of_range, make_error};
 use crate::raw::object::Polygon;
 use num_traits::FromPrimitive;
 use std::collections::hash_map::{Entry, HashMap};
@@ -130,10 +130,7 @@ impl<I: FromPrimitive + Copy> FromRawVertex<I> for Vertex {
                         };
                         let index = match I::from_usize(vb.len()) {
                             Some(val) => val,
-                            None => make_error!(
-                                IndexOutOfRange,
-                                "Unable to convert the index from usize"
-                            ),
+                            None => return index_out_of_range::<_, I>(vb.len()),
                         };
                         vb.push(vertex);
                         entry.insert(index);
@@ -207,7 +204,7 @@ impl<I: FromPrimitive> FromRawVertex<I> for Position {
             let mut map = |pi: usize| -> ObjResult<()> {
                 ib.push(match I::from_usize(pi) {
                     Some(val) => val,
-                    None => make_error!(IndexOutOfRange, "Unable to convert the index from usize"),
+                    None => return index_out_of_range::<_, I>(pi),
                 });
                 Ok(())
             };
@@ -285,10 +282,7 @@ impl<I: FromPrimitive + Copy> FromRawVertex<I> for TexturedVertex {
                         };
                         let index = match I::from_usize(vb.len()) {
                             Some(val) => val,
-                            None => make_error!(
-                                IndexOutOfRange,
-                                "Unable to convert the index from usize"
-                            ),
+                            None => return index_out_of_range::<_, I>(vb.len()),
                         };
                         vb.push(vertex);
                         entry.insert(index);

--- a/obj-rs/tests/issue-63.rs
+++ b/obj-rs/tests/issue-63.rs
@@ -5,11 +5,7 @@ fn do_test<V: obj::FromRawVertex<u8> + std::fmt::Debug>(test_case: &str) {
     let err = load_obj::<V, _, _>(Cursor::new(test_case))
         .expect_err("Should error out due to index out of bounds");
     if let obj::ObjError::Load(err) = err {
-        let expected_error = obj::LoadError::new(
-            obj::LoadErrorKind::IndexOutOfRange,
-            "Unable to convert the index from usize",
-        );
-        assert_eq!(err.to_string(), expected_error.to_string());
+        assert_eq!(*err.kind(), obj::LoadErrorKind::IndexOutOfRange);
     } else {
         panic!("Expected a LoadError");
     }


### PR DESCRIPTION
Following the discussion in https://github.com/simnalamburt/obj-rs/issues/72 this PR adds additional information to the error message when the number of polygons is too large for a type `I` to hold. https://github.com/simnalamburt/obj-rs/blob/b1e75fdddd2f66c11e0e86da21da9fc8b1e1dd6e/obj-rs/src/lib.rs#L58
In detail the following was done:
1) Changed the type of error message in https://github.com/simnalamburt/obj-rs/blob/b1e75fdddd2f66c11e0e86da21da9fc8b1e1dd6e/obj-rs/src/error.rs#L68 to accommodate the dynamic nature of the error message, as now it prints the type in question + the length of the vector that becomes too large.
2) `make_error!` macro https://github.com/simnalamburt/obj-rs/blob/b1e75fdddd2f66c11e0e86da21da9fc8b1e1dd6e/obj-rs/src/error.rs#L129 adds `to_string()` to make existing calls using static error messages compile.

Closes https://github.com/simnalamburt/obj-rs/issues/72